### PR TITLE
Remove named Module constructor in m.js

### DIFF
--- a/lib/m/module.js
+++ b/lib/m/module.js
@@ -26,7 +26,7 @@
         this.sandbox.publish('module:create', options, this);
       }
 
-      Module.__super__.constructor.apply(this, arguments);
+      Backbone.View.apply(this, arguments);
     },
 
     /* Returns the type of the module */


### PR DESCRIPTION
Because Module was referenced inside the constructor named Module, uglify.js 
compressor renamed the constructor as well as any references to it inside. As 
a result, the reference to super was incorrect.

This bug only appears when assets are compressed through uglify and in IE 
browsers.
### Example

``` javascript
var Module = Backbone.View.extend({
    sandbox: null,
    constructor: function Module(options) {
      // Need to assign the sandbox before calling super to allow the
      // #initialize method to access it.
      this.sandbox = (options && options.sandbox) || null;
      if (this.sandbox && typeof this.sandbox.publish === 'function') {
        this.sandbox.publish('module:create', options, this);
      }

      Module.__super__.constructor.apply(this, arguments);
    }
    // etc
```

compiled into

``` javascript
var Module=Backbone.View.extend({
   sandbox:null,
   constructor: function t(e) {
      this.sandbox=e&&e.sandbox||null,this.sandbox&&"function"==typeof this.sandbox.publish&&this.sandbox.publish("module:create",e,this);
       t.__super__.constructor.apply(this,arguments)
  }
  // etc
```
### Demo

See: http://jsfiddle.net/m4SZH/1/
Both modules work fine in modern browsers, but `BadModule` fails in IE8.
(Don't mind that JSfiddle doesn't really work on IE8, the code still runs! :dancers: )
