### PR TITLE
Clean up handlers when an module is removed from the document

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ pkgdir:
 	@mkdir -p $(PKGDIR)
 
 concat: pkgdir
-	@cat lib/m.js lib/m/{create,sandbox,events,module}.js > $(PKGDIR)/m.js
+	@cat lib/m.js lib/m/{create,remove,sandbox,events,module}.js > $(PKGDIR)/m.js
 	@echo Created $(PKGDIR)/m.js
 
 minify: concat

--- a/lib/m/module.js
+++ b/lib/m/module.js
@@ -27,6 +27,8 @@
       }
 
       Module.__super__.constructor.apply(this, arguments);
+
+      this.$el.on('remove', _.bind(this.remove, this));
     },
 
     /* Returns the type of the module */

--- a/lib/m/remove.js
+++ b/lib/m/remove.js
@@ -1,0 +1,19 @@
+/* jQuery special event whose handler is called only when the element
+ * is removed from DOM. Useful for tearing down a module on DOM removal.
+ *
+ * Inspired by http://blog.alexmaccaw.com/jswebapps-memory-management
+ *
+ * Example
+ *   var element = document.createElement('div');
+ *   jQuery(element).on('remove', tearDown);
+ *   element.remove(); // tearDown function gets called.
+ */
+(function (jQuery) {
+
+  jQuery.event.special.remove = {
+    remove: function (event) {
+      if (event.handler) { event.handler(); }
+    }
+  };
+
+})(this.jQuery);

--- a/test/index.html
+++ b/test/index.html
@@ -13,6 +13,7 @@
     <script src="../vendor/broadcast.js"></script>
     <script src="../lib/m.js"></script>
     <script src="../lib/m/create.js"></script>
+    <script src="../lib/m/remove.js"></script>
     <script src="../lib/m/sandbox.js"></script>
     <script src="../lib/m/events.js"></script>
     <script src="../lib/m/module.js"></script>
@@ -33,6 +34,7 @@
       });
     </script>
     <script src="./specs/create-spec.js"></script>
+    <script src="./specs/remove-spec.js"></script>
     <script src="./specs/module-spec.js"></script>
     <script src="./specs/events-spec.js"></script>
     <script src="./specs/sandbox-spec.js"></script>

--- a/test/specs/module-spec.js
+++ b/test/specs/module-spec.js
@@ -750,6 +750,13 @@ describe('m.module()', function () {
       assert.calledWith(target, 'module:create', this.options, this.subject);
     });
 
+    it('tears down when module element is removed', function () {
+      var target = this.subject.teardown = sinon.spy();
+      this.fixture.appendChild(this.subject.el);
+      this.subject.$el.remove();
+      assert.called(target);
+    });
+
     describe('.$()', function () {
       it('find children within the module element', function () {
         this.subject.$el.append(jQuery('<input /><input />'));

--- a/test/specs/remove-spec.js
+++ b/test/specs/remove-spec.js
@@ -1,0 +1,36 @@
+describe('jQuery.event.special.remove', function () {
+
+  beforeEach(function () {
+    this.let('$element', function () {
+      return jQuery('<div>');
+    });
+
+    this.let('$child', function () {
+      return jQuery('<div>');
+    });
+
+    this.$element.append(this.$child);
+  });
+
+  it('calls the event handler on remove', function () {
+    var target = sinon.spy();
+    this.$element.on('remove', target);
+    this.$element.remove();
+    assert.called(target);
+  });
+
+  it('calls the children event handlers on remove', function () {
+    var target = sinon.spy();
+    this.$child.on('remove', target);
+    this.$element.remove();
+    assert.called(target);
+  });
+
+  it('calls the event handler when element replaced', function () {
+    var target = sinon.spy();
+    this.$child.on('remove', target);
+    this.$element.html('');
+    assert.called(target);
+  });
+
+});


### PR DESCRIPTION
We can use the jQuery special events to listen for when the element is removed from the document and clean up the module handlers.

Very nicely documented here: http://blog.alexmaccaw.com/jswebapps-memory-management
