### PR TITLE
Move all module.* methods into a separate constructor function

### DIFF
--- a/lib/m.js
+++ b/lib/m.js
@@ -1,4 +1,4 @@
-(function (exports) {
+(function (exports, mixin, create, inherit, Broadcast) {
   var _m = exports.m;
 
   exports.m = {};
@@ -13,4 +13,4 @@
     exports.m = _m;
     return m;
   };
-})(this);
+})(this, this.mixin, this.create, this.inherit, this.Broadcast);

--- a/lib/m.js
+++ b/lib/m.js
@@ -2,6 +2,12 @@
   var _m = exports.m;
 
   exports.m = {};
+  exports.m.utils = {
+    mixin:   mixin.noConflict(),
+    create:  create.noConflict(),
+    inherit: inherit.noConflict()
+  };
+  exports.m.Events = Broadcast.noConflict();
   exports.m.noConflict = function () {
     var m = exports.m;
     exports.m = _m;

--- a/lib/m/create.js
+++ b/lib/m/create.js
@@ -1,4 +1,4 @@
-(function (m, inherit) {
+(function (m) {
 
   /* Creates a new constructor function with the provided prototype and class
    * methods. New sub objects can be created using the .extend() method. The
@@ -29,7 +29,7 @@
     if (!instance || !instance.hasOwnProperty('constructor') || typeof instance.constructor !== 'function') {
       throw new Error('The instance methods argument must have a constructor property');
     }
-    return inherit(inherit.constructor(Object), instance, properties);
+    return m.utils.inherit(m.utils.inherit.constructor(Object), instance, properties);
   };
 
-})(this.m = this.m || {}, this.inherit);
+})(this.m = this.m || {});

--- a/lib/m/events.js
+++ b/lib/m/events.js
@@ -13,9 +13,9 @@
  *   this.sandbox.subscribe('dropdown:open', this.onOpen, this);
  *   this.sandbox.publish('dropdown:open');
  */
-(function (Broadcast, m, _) {
+(function (m, _) {
   // Create a happy new global event object with a familiar api.
-  var hub = new Broadcast();
+  var hub = new m.Events();
 
   /* Allow events to be paused, this will collect any events published while
    * paused and republished them when .resume() is called. This is useful
@@ -147,4 +147,4 @@
     _.extend(instance, new m.SandboxEvents(m.events));
   });
 
-})(this.Broadcast, this.m, this._);
+})(this.m, this._);

--- a/lib/m/module.js
+++ b/lib/m/module.js
@@ -640,6 +640,7 @@
   m.module = module;
   m.module.Module = Module;
   m.module.ModuleFactory = ModuleFactory;
+  m.module.ModuleRegistry = ModuleRegistry;
 
   // Unbind all event handlers when a module is removed from the document.
   m.events.subscribe('module:remove', function (module) {

--- a/lib/m/module.js
+++ b/lib/m/module.js
@@ -125,20 +125,22 @@
       this.undelegateEvents();
 
       for (key in events) {
-        handler = events[key];
-        if (typeof handler !== 'function') { handler = this[handler]; }
-        if (!handler) { continue; }
+        if (_.has(events, key)) {
+          handler = events[key];
+          if (typeof handler !== 'function') { handler = this[handler]; }
+          if (!handler) { continue; }
 
-        handler  = _.bind(handler, this);
-        parts    = key.split(' ');
-        event    = parts.shift();
-        selector = parts.join(' ');
-        event   += '.m:delegates:' + this.cid;
+          handler  = _.bind(handler, this);
+          parts    = key.split(' ');
+          event    = parts.shift();
+          selector = parts.join(' ');
+          event   += '.m:delegates:' + this.cid;
 
-        if (selector) {
-          this.$el.delegate(selector, event, handler);
-        } else {
-          this.$el.on(event, handler);
+          if (selector) {
+            this.$el.delegate(selector, event, handler);
+          } else {
+            this.$el.on(event, handler);
+          }
         }
       }
       return this;

--- a/lib/m/module.js
+++ b/lib/m/module.js
@@ -421,200 +421,220 @@
     }
   });
 
-  /* The core method. This creates a new ModuleFactory and adds it to the
-   * registry. This should be used to create new view objects.
-   *
-   * type    - The type of the module to register.
-   * methods - An optional object literal of methods to add to the Module
-   *           prototype.
-   *
-   * Examples
-   *
-   *   module('load-more', {
-   *     initialize: function () {
-   *       this.$el.on('click', this._onClick)
-   *     _onClick: (event) function () {
-   *   })
-   *
-   *   module('load-more').methods(object).defaults(page: 1)
-   *
-   * Returns a ModuleFactory instance.
-   */
-  function module(type, methods) {
-    if (module.find(type)) {
-      throw new Error('Module ' + type + ' has already been registered');
-    }
+  var ModuleRegistry = m.create({
+    /* Holds all ModuleFactory objects by namespace. */
+    registry: null,
 
-    return module.registry[type] = new module.ModuleFactory(type, module.find).methods(methods);
-  }
+    /* Holds all instances of all created views on the page. */
+    instances: null,
 
-  /* Holds all ModuleFactory objects by namespace. */
-  module.registry = {};
+    /* Initialize instance variables.
+     *
+     * Returns nothing.
+     */
+    constructor: function ModuleRegistry() {
+      this.registry  = {};
+      this.instances = {};
+    },
 
-  /* Holds all instances of all created views on the page. */
-  module.instances = {};
-
-  /* Looks up a module in the registry */
-  module.find = function (type) {
-    return module.registry[type] || null;
-  };
-
-  module.create = function (type, element, options) {
-    var factory = module.find(type);
-    return module.instance(factory, element, options);
-  };
-
-  /* Initializes elements on the page immediately. */
-  module.initialize = function (element) {
-    _.each(module.registry, function (factory) {
-      if (factory.isDeferred()) {
-        return module.delegate(factory);
+    /* The core method. This creates a new ModuleFactory and adds it to the
+     * registry. This should be used to create new view objects.
+     *
+     * type    - The type of the module to register.
+     * methods - An optional object literal of methods to add to the Module
+     *           prototype.
+     *
+     * Examples
+     *
+     *   module('load-more', {
+     *     initialize: function () {
+     *       this.$el.on('click', this._onClick)
+     *     _onClick: (event) function () {
+     *   })
+     *
+     *   module('load-more').methods(object).defaults(page: 1)
+     *
+     * Returns a ModuleFactory instance.
+     */
+    define: function (type, methods) {
+      if (this.find(type)) {
+        throw new Error('Module ' + type + ' has already been registered');
       }
 
-      var matches = jQuery(factory.selector, element);
-      _.each(matches,  function (element) {
-        module.instance(factory, element);
-      });
-    });
+      return this.registry[type] = new module.ModuleFactory(type, this.find).methods(methods);
+    },
 
-    return this;
-  };
+    /* Looks up a module in the registry */
+    find: function (type) {
+      return this.registry[type] || null;
+    },
 
-  /* Sets up module delegation on the document */
-  module.delegate = function (factory) {
-    if (factory.hasDelegated === true) {
-      return;
-    }
+    create: function (type, element, options) {
+      var factory = this.find(type);
+      return this.instance(factory, element, options);
+    },
 
-    var document = jQuery(window.document);
-    _.each(factory.events, function (options) {
-      var data = {factory: factory, options: options};
-      document.on(options.on, factory.selector, data, module.delegate.handler);
-    });
+    /* Initializes elements on the page immediately. */
+    initialize: function (element) {
+      _.each(this.registry, function (factory) {
+        if (factory.isDeferred()) {
+          return this.delegate(factory);
+        }
 
-    factory.hasDelegated = true;
-  };
+        var matches = jQuery(factory.selector, element);
+        _.each(matches,  function (element) {
+          this.instance(factory, element);
+        }, this);
+      }, this);
 
-  /* An event handler called each time a delegated event is triggered */
-  module.delegate.handler = function (event) {
-    var factory = event.data.factory;
-    var options = event.data.options;
+      return this;
+    },
 
-    // Return early if meta key is held down, as this opens the browser
-    // default action in a new tab (in most browsers).
-    if (event.metaKey) {
-      return;
-    }
-
-    if (options.preventDefault !== false) {
-      event.preventDefault();
-    }
-
-    module.instance(factory, event.currentTarget, {}, event);
-  };
-
-  /* Create a single instance of a Module from the ModuleFactory and element
-   * provided.
-   *
-   * factory - The ModuleFactory object used to create this instance
-   * element - The element to bind this instance to
-   * options - The options object to set/override module options for this instance. Optional.
-   * event - The event that triggered initialization. Used when initialization is deferred.
-   */
-  module.instance = function (factory, element, options, event) {
-    event = event || null;
-    var instance = module.findInstance(factory, element);
-    if (instance) {
-      return instance.run(event);
-    }
-
-    var sandbox = m.sandbox();
-
-    options = _.extend(factory.extract(element), options);
-    options.el = element;
-    options.sandbox = sandbox;
-
-    instance = factory.build().create(options);
-    instance.on('remove', _.bind(module.removeInstance, null, instance));
-    instance.run(event);
-
-    module.addInstance(instance);
-
-    return instance;
-  };
-
-  /* Finds an existing instance of a module */
-  module.findInstance = function (factory, element) {
-    return _.find(module.instances[factory.type], function (instance) {
-      return instance.el === element;
-    }) || null;
-  };
-
-  /* Adds a new instance to the cache */
-  module.addInstance = function (instance) {
-    var instances = module.instances[instance.type()] || [];
-    instances.push(instance);
-    module.instances[instance.type()] = instances;
-  };
-
-  /* Removes an instance from the cache */
-  module.removeInstance = function (instance) {
-    var index = module.instances[instance.type()].indexOf(instance);
-    module.instances[instance.type()].splice(index, 1);
-  };
-
-  /* Debugging tool for finding modules created on a particular element. Will
-   * either return an array of all modules on an element or if a type is
-   * provided, just that instance.
-   *
-   * element - The element to lookup.
-   * type    - A specific module type to return.
-   *
-   * Examples
-   *
-   *   // In the browser console the selected element is $0.
-   *   m.module.lookup($0); //=> [ModuleA, ModuleB, ModuleC]
-   *
-   *   m.module.lookup($0, 'a') //=> ModuleA
-   *
-   * Returns an array of modules or the one specified by type.
-   */
-  module.lookup = function (element, type) {
-    var matches = _.map(module.instances, function (modules, currentType) {
-      return _.find(modules, function (module) {
-        return module.el === element && (!type || type === currentType);
-      });
-    });
-
-    matches = _.flatten(_.compact(matches));
-
-    return type ? (matches[0] || null) : matches;
-  };
-
-  /* Extends the Module.prototype. Libraries should use this to add properties
-   * to the module instances.
-   *
-   * properties - An object literal of properties to add to the sandbox.
-   *
-   * Examples
-   *
-   *   module.mixin({
-   *     doSomething: function (path) { jQuery.ajax(path) }
-   *   });
-   *
-   * Returns itself.
-   */
-  module.mixin = function (properties) {
-    var prototype = Module.prototype;
-    _.each(properties, function (value, key) {
-      if (prototype[key]) {
-        throw new Error('Cannot overwrite existing property ' + key + ' on Module prototype');
+    /* Sets up module delegation on the document */
+    delegate: function (factory) {
+      if (factory.hasDelegated === true) {
+        return;
       }
-      prototype[key] = value;
-    }, this);
 
-    return this;
-  };
+      var document = jQuery(window.document);
+      _.each(factory.events, function (options) {
+        var data = {factory: factory, options: options};
+        document.on(options.on, factory.selector, data, this.delegateHandler);
+      }, this);
+
+      factory.hasDelegated = true;
+    },
+
+    /* An event handler called each time a delegated event is triggered */
+    delegateHandler: function (event) {
+      var factory = event.data.factory;
+      var options = event.data.options;
+
+      // Return early if meta key is held down, as this opens the browser
+      // default action in a new tab (in most browsers).
+      if (event.metaKey) {
+        return;
+      }
+
+      if (options.preventDefault !== false) {
+        event.preventDefault();
+      }
+
+      this.instance(factory, event.currentTarget, {}, event);
+    },
+
+    /* Create a single instance of a Module from the ModuleFactory and element
+     * provided.
+     *
+     * factory - The ModuleFactory object used to create this instance
+     * element - The element to bind this instance to
+     * options - The options object to set/override module options for this instance. Optional.
+     * event - The event that triggered initialization. Used when initialization is deferred.
+     */
+    instance: function (factory, element, options, event) {
+      event = event || null;
+      var instance = this.findInstance(factory, element);
+      if (instance) {
+        return instance.run(event);
+      }
+
+      var sandbox = m.sandbox();
+
+      options = _.extend(factory.extract(element), options);
+      options.el = element;
+      options.sandbox = sandbox;
+
+      instance = factory.build().create(options);
+      instance.on('remove', _.bind(this.removeInstance, null, instance));
+      instance.run(event);
+
+      this.addInstance(instance);
+
+      return instance;
+    },
+
+    /* Finds an existing instance of a module */
+    findInstance: function (factory, element) {
+      return _.find(this.instances[factory.type], function (instance) {
+        return instance.el === element;
+      }) || null;
+    },
+
+    /* Adds a new instance to the cache */
+    addInstance: function (instance) {
+      var instances = this.instances[instance.type()] || [];
+      instances.push(instance);
+      this.instances[instance.type()] = instances;
+    },
+
+    /* Removes an instance from the cache */
+    removeInstance: function (instance) {
+      var index = this.instances[instance.type()].indexOf(instance);
+      this.instances[instance.type()].splice(index, 1);
+    },
+
+    /* Debugging tool for finding modules created on a particular element. Will
+     * either return an array of all modules on an element or if a type is
+     * provided, just that instance.
+     *
+     * element - The element to lookup.
+     * type    - A specific module type to return.
+     *
+     * Examples
+     *
+     *   // In the browser console the selected element is $0.
+     *   m.module.lookup($0); //=> [ModuleA, ModuleB, ModuleC]
+     *
+     *   m.module.lookup($0, 'a') //=> ModuleA
+     *
+     * Returns an array of modules or the one specified by type.
+     */
+    lookup: function (element, type) {
+      var matches = _.map(this.instances, function (modules, currentType) {
+        return _.find(modules, function (module) {
+          return module.el === element && (!type || type === currentType);
+        });
+      });
+
+      matches = _.flatten(_.compact(matches));
+
+      return type ? (matches[0] || null) : matches;
+    },
+
+    /* Extends the Module.prototype. Libraries should use this to add properties
+     * to the module instances.
+     *
+     * properties - An object literal of properties to add to the sandbox.
+     *
+     * Examples
+     *
+     *   module.mixin({
+     *     doSomething: function (path) { jQuery.ajax(path) }
+     *   });
+     *
+     * Returns itself.
+     */
+    mixin: function (properties) {
+      var prototype = Module.prototype;
+      _.each(properties, function (value, key) {
+        if (prototype[key]) {
+          throw new Error('Cannot overwrite existing property ' + key + ' on Module prototype');
+        }
+        prototype[key] = value;
+      }, this);
+
+      return this;
+    }
+  });
+
+  // Create the core module function. This is essentially a wrapper around
+  // ModuleRegistry#define(), by copying the methods onto the function we
+  // get a convinient shortcut.
+  var module = (function () {
+    return _.extend(function registry() {
+      return registry.define.apply(registry, arguments);
+    }, new ModuleRegistry());
+  })();
 
   /* Export to the window */
   m.module = module;

--- a/lib/m/module.js
+++ b/lib/m/module.js
@@ -6,8 +6,8 @@
  * tearing down DOM elements. In addition it receives a sandbox object which is
  * it's communication with the rest of the page.
  */
-(function (m, jQuery, Broadcast, inherit, _) {
-  var Module = inherit(Broadcast, {
+(function (m, jQuery, _) {
+  var Module = m.utils.inherit(m.Events, {
     el: null,
     $el: null,
     cid: null,
@@ -26,7 +26,7 @@
     constructor: function Module(options) {
       options = options || {};
 
-      Broadcast.call(this);
+      m.Events.call(this);
 
       this.el = options.el || document.createElement('div');
       this.$el = jQuery(this.el);
@@ -169,7 +169,7 @@
     },
 
     extend: function (proto, methods) {
-      return inherit(this, proto, methods);
+      return m.utils.inherit(this, proto, methods);
     }
   });
 
@@ -652,4 +652,4 @@
     m.module.initialize(module.el);
   });
 
-})(this.m = this.m || {}, this.jQuery, this.Broadcast, this.inherit, this._);
+})(this.m = this.m || {}, this.jQuery, this._);

--- a/test/specs/events-spec.js
+++ b/test/specs/events-spec.js
@@ -6,8 +6,8 @@ describe('m.events', function () {
     events._callbacks = callbacks;
   });
 
-  it('is an instance of Broadcast', function () {
-    assert.instanceOf(events, window.Broadcast);
+  it('is an instance of Events', function () {
+    assert.instanceOf(events, m.Events);
   });
 
   describe('', function () {

--- a/test/specs/module-spec.js
+++ b/test/specs/module-spec.js
@@ -748,8 +748,8 @@ describe('m.module()', function () {
       });
     });
 
-    it('is an instance of Broadcast', function () {
-      assert.instanceOf(this.subject, window.Broadcast);
+    it('is an instance of Events', function () {
+      assert.instanceOf(this.subject, m.Events);
     });
 
     it('assigns .el as the element option', function () {

--- a/test/specs/module-spec.js
+++ b/test/specs/module-spec.js
@@ -294,7 +294,7 @@ describe('m.module()', function () {
       assert.calledWith(this.document.on, 'click', '[data-test]', {
         factory: this.factory,
         options: this.events[0]
-      }, module.delegate.handler);
+      }, module.delegateHandler);
     });
 
     it('sets the `hasDelegated` flag on the factory', function () {
@@ -309,7 +309,7 @@ describe('m.module()', function () {
     });
   });
 
-  describe('module.delegate.handler', function () {
+  describe('module.delegateHandler', function () {
     beforeEach(function () {
       this.let('element', document.createElement('div'));
       this.let('factory', new ModuleFactory('test'));
@@ -325,18 +325,18 @@ describe('m.module()', function () {
     });
 
     it('instantiates the module with the factory and current event target', function () {
-      module.delegate.handler(this.event);
+      module.delegateHandler(this.event);
       assert.calledWith(module.instance, this.factory, this.element);
     });
 
     it('prevents the default event action', function () {
-      module.delegate.handler(this.event);
+      module.delegateHandler(this.event);
       assert.isTrue(this.event.isDefaultPrevented());
     });
 
     it('does not prevent the default event action if options.preventDefault is false', function () {
       this.event.data.options.preventDefault = false;
-      module.delegate.handler(this.event);
+      module.delegateHandler(this.event);
       assert.isFalse(this.event.isDefaultPrevented());
     });
 
@@ -346,14 +346,14 @@ describe('m.module()', function () {
         event.data.options.callback = value;
 
         assert.doesNotThrow(function () {
-          module.delegate.handler(event);
+          module.delegateHandler(event);
         });
       }, this);
     });
 
     it('does nothing if the meta key is held down', function () {
       this.event.metaKey = true;
-      module.delegate.handler(this.event);
+      module.delegateHandler(this.event);
       assert.notCalled(module.instance);
     });
   });


### PR DESCRIPTION
This makes the code more portable and easier to test. Key changes are:
- Creation of the `ModuleRegistry` constructor, this handles dom events and creation and registration of modules.
- Moving broadcast and inheritance methods onto a `utils` object.
- `m.module()` still exists but is now just a wrapper around `ModuleRegistry`.
